### PR TITLE
konabess: Add support for Snapdragon 8s Gen 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
   * Snapdragon 8+ Gen 1
   * Snapdragon 8 Gen 2
   * Snapdragon 8 Gen 3
-  * Snapdragon 8s Gen 3
+  * Snapdragon 8s Gen 3 
+  * Snapdragon 8s Gen 4
 
 
 ### Overview

--- a/app/src/main/java/xzr/konabess/ChipInfo.java
+++ b/app/src/main/java/xzr/konabess/ChipInfo.java
@@ -26,6 +26,7 @@ public class ChipInfo {
         kalama_sg_singleBin,
         sun,
         canoe,
+        tuna,
         unknown
     }
 
@@ -34,7 +35,8 @@ public class ChipInfo {
                 || type == ChipInfo.type.kalama || type == ChipInfo.type.diwali
                 || type == ChipInfo.type.ukee_singleBin || type == ChipInfo.type.pineapple
                 || type == ChipInfo.type.cliffs_singleBin || type == ChipInfo.type.cliffs_7_singleBin
-                || type == ChipInfo.type.kalama_sg_singleBin || type == ChipInfo.type.sun || type == ChipInfo.type.canoe)
+                || type == ChipInfo.type.kalama_sg_singleBin || type == ChipInfo.type.sun 
+                || type == ChipInfo.type.canoe || type == ChipInfo.type.tuna)
             return 16;
         return 11;
     }
@@ -46,7 +48,8 @@ public class ChipInfo {
                 || type == ChipInfo.type.kalama || type == ChipInfo.type.diwali
                 || type == ChipInfo.type.ukee_singleBin || type == ChipInfo.type.pineapple
                 || type == ChipInfo.type.cliffs_singleBin || type == ChipInfo.type.cliffs_7_singleBin
-                || type == ChipInfo.type.kalama_sg_singleBin || type == ChipInfo.type.sun || type == ChipInfo.type.canoe;
+                || type == ChipInfo.type.kalama_sg_singleBin || type == ChipInfo.type.sun 
+                || type == ChipInfo.type.canoe || type == ChipInfo.type.tuna;
     }
 
     public static boolean checkChipGeneral(type input) {
@@ -109,6 +112,8 @@ public class ChipInfo {
                 return activity.getResources().getString(R.string.sd8e);
             case canoe:
                 return activity.getResources().getString(R.string.sd8e_gen5);
+            case tuna:
+                return activity.getResources().getString(R.string.sd8sg4);
         }
         return activity.getResources().getString(R.string.unknown);
     }
@@ -154,6 +159,8 @@ public class ChipInfo {
                 return rpmh_levels_sun.levels;
             else if (ChipInfo.which == type.canoe)
                 return rpmh_levels_canoe.levels;
+            else if (ChipInfo.which == type.tuna)
+                return rpmh_levels_tuna.levels;
 
             return new int[]{};
         }
@@ -196,6 +203,8 @@ public class ChipInfo {
                 return rpmh_levels_sun.level_str;
             else if (ChipInfo.which == type.canoe)
                 return rpmh_levels_canoe.level_str;
+            else if (ChipInfo.which == type.tuna)
+                return rpmh_levels_tuna.level_str;
 
             return new String[]{};
         }
@@ -668,6 +677,34 @@ public class ChipInfo {
                 "TURBO_L4",
                 "SUPER_TURBO",
                 "SUPER_TURBO_NO_CPR"
+        };
+    }
+
+    private static class rpmh_levels_tuna {
+        public static final int[] levels = {16, 48, 52, 56, 60, 64, 80, 96, 128, 144, 192,
+                224, 256, 320, 336, 352, 384, 400, 416, 432, 448};
+        public static final String[] level_str = {
+                "RETENTION",
+                "MIN_SVS",
+                "LOW_SVS_D2",
+                "LOW_SVS_D1",
+                "LOW_SVS_D0",
+                "LOW_SVS",
+                "LOW_SVS_L1",
+                "LOW_SVS_L2",
+                "SVS",
+                "SVS_L0",
+                "SVS_L1",
+                "SVS_L2",
+                "NOM",
+                "NOM_L1",
+                "NOM_L2",
+                "NOM_L3",
+                "TURBO",
+                "TURBO_L0",
+                "TURBO_L1",
+                "TURBO_L2",
+                "TURBO_L3"
         };
     }
 }

--- a/app/src/main/java/xzr/konabess/GpuTableEditor.java
+++ b/app/src/main/java/xzr/konabess/GpuTableEditor.java
@@ -80,6 +80,18 @@ public class GpuTableEditor {
                 bracket++;
                 continue;
             }
+            if (ChipInfo.which == ChipInfo.type.tuna
+                    && this_line.contains("qcom,gpu-pwrlevels-")
+                    && !this_line.contains("compatible = ")
+                    && !this_line.contains("qcom,gpu-pwrlevel-bins")) {
+                start = i;
+                if (bin_position < 0)
+                    bin_position = i;
+                if (bracket != 0)
+                    throw new Exception();
+                bracket++;
+                continue;
+            }
             if ((ChipInfo.which == ChipInfo.type.kona
                     || ChipInfo.which == ChipInfo.type.msmnile
                     || ChipInfo.which == ChipInfo.type.lahaina
@@ -120,15 +132,21 @@ public class GpuTableEditor {
                     || ChipInfo.which == ChipInfo.type.diwali
                     || ChipInfo.which == ChipInfo.type.pineapple
                     || ChipInfo.which == ChipInfo.type.sun
-                    || ChipInfo.which == ChipInfo.type.canoe)) {
+                    || ChipInfo.which == ChipInfo.type.canoe
+                    || ChipInfo.which == ChipInfo.type.tuna)) {
                 end = i;
                 if (end >= start) {
-                    decode_bin(lines_in_dts.subList(start, end + 1));
-                    lines_in_dts.subList(start, end + 1).clear();
+                    try {
+                        decode_bin(lines_in_dts.subList(start, end + 1));
+                        int removedLines = end - start + 1;
+                        lines_in_dts.subList(start, end + 1).clear();
+                        i = i - removedLines; // Adjust index after removing lines
+                    } catch (Exception e) {
+                        throw e;
+                    }
                 } else {
                     throw new Exception();
                 }
-                i = start - 1;
                 start = -1;
                 continue;
             }
@@ -237,7 +255,8 @@ public class GpuTableEditor {
                 || ChipInfo.which == ChipInfo.type.diwali
                 || ChipInfo.which == ChipInfo.type.pineapple
                 || ChipInfo.which == ChipInfo.type.sun
-                || ChipInfo.which == ChipInfo.type.canoe) {
+                || ChipInfo.which == ChipInfo.type.canoe
+                || ChipInfo.which == ChipInfo.type.tuna) {
             for (int bin_id = 0; bin_id < bins.size(); bin_id++) {
                 lines.add("qcom,gpu-pwrlevels-" + bins.get(bin_id).id + " {");
                 lines.addAll(bins.get(bin_id).header);
@@ -571,7 +590,8 @@ public class GpuTableEditor {
                 || ChipInfo.which == ChipInfo.type.cliffs_7_singleBin
                 || ChipInfo.which == ChipInfo.type.kalama_sg_singleBin
                 || ChipInfo.which == ChipInfo.type.sun
-                || ChipInfo.which == ChipInfo.type.canoe)
+                || ChipInfo.which == ChipInfo.type.canoe
+                || ChipInfo.which == ChipInfo.type.tuna)
             return 1;
         if (ChipInfo.which == ChipInfo.type.kona || ChipInfo.which == ChipInfo.type.kona_singleBin
                 || ChipInfo.which == ChipInfo.type.msmnile || ChipInfo.which == ChipInfo.type.msmnile_singleBin
@@ -609,7 +629,6 @@ public class GpuTableEditor {
             long freq = getFrequencyFromLevel(level);
             if (freq == 0)
                 continue;
-            ;
             ParamAdapter.item item = new ParamAdapter.item();
             item.title = freq / 1000000 + "MHz";
             item.subtitle = "";

--- a/app/src/main/java/xzr/konabess/KonaBessCore.java
+++ b/app/src/main/java/xzr/konabess/KonaBessCore.java
@@ -309,6 +309,11 @@ public class KonaBessCore {
                 dtb.id = i;
                 dtb.type = ChipInfo.type.canoe;
                 dtbs.add(dtb);
+            } else if (checkChip(context, i, "Tuna 7 SoC") || checkChip(context, i, "Tuna SoC")) {
+                dtb dtb = new dtb();
+                dtb.id = i;
+                dtb.type = ChipInfo.type.tuna;
+                dtbs.add(dtb);
             }
         }
     }

--- a/app/src/main/java/xzr/konabess/KonaBessStr.java
+++ b/app/src/main/java/xzr/konabess/KonaBessStr.java
@@ -47,6 +47,8 @@ public class KonaBessStr {
             return convert_bins_sun(which, activity);
         else if (ChipInfo.which == ChipInfo.type.canoe)
             return convert_bins_canoe(which, activity);
+        else if (ChipInfo.which == ChipInfo.type.tuna)
+            return convert_bins_tuna(which, activity);
 
         throw new Exception();
     }
@@ -254,5 +256,17 @@ public class KonaBessStr {
         return ChipInfo.shouldIgnoreVoltTable(ChipInfo.which)
                 ? activity.getResources().getString(R.string.help_msg_aio)
                 : activity.getResources().getString(R.string.help_msg);
+    }
+
+    public static String convert_bins_tuna(int which, Activity activity) {
+        switch (which) {
+            case 0:
+                return "Speed Bin 0 (0x0)";
+            case 1:
+                return "Speed Bin 1 (0xd8)";
+            case 2:
+                return "Speed Bin 2 (0xf2)";
+        }
+        return activity.getResources().getString(R.string.unknown_table) + which;
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -133,4 +133,5 @@
      <string name="sdg3xg2">Snapdragon G3x Gen2</string>
      <string name="sd8e">Snapdragon 8 Elite</string>
      <string name="sd8e_gen5">Snapdragon 8 Elite Gen5</string>
+     <string name="sd8sg4">Snapdragon 8s Gen 4</string>
  </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -132,4 +132,5 @@
      <string name="sdg3xg2">骁龙 G3x Gen2</string>
      <string name="sd8e">骁龙 8 Elite</string>
      <string name="sd8e_gen5">骁龙 8 Elite Gen5</string>
+     <string name="sd8sg4">骁龙 8s Gen 4</string>
  </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,4 +132,5 @@
      <string name="sdg3xg2">Snapdragon G3x Gen2</string>
      <string name="sd8e">Snapdragon 8 Elite</string>
      <string name="sd8e_gen5">Snapdragon 8 Elite Gen5</string>
+     <string name="sd8sg4">Snapdragon 8s Gen 4</string>
  </resources>


### PR DESCRIPTION
1. Introduced new ChipInfo type for Tuna SoC.
2. Added "Snapdragon 8s Gen 4" string resources for multiple languages. Updated ChipInfo logic to handle Tuna-specific GPU bin counts and voltage levels, including a new rpmh_levels_tuna definition. Enabled detection of Tuna SoC in KonaBessCore for "Tuna 7 SoC" and "Tuna SoC" identifiers.
3. Implemented Tuna-specific GPU speed bin conversion in KonaBessStr. Modified GpuTableEditor to parse and write Tuna-specific GPU power levels.
4. Updated README.md to list "Snapdragon 8s Gen 4" as a supported chip.